### PR TITLE
Refactor the TCP accept mechanism

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -28,7 +28,10 @@
  */
 
 #include "server.h"
+#include "http.h"
 #include "picohttpparser.h"
+
+#define HTTP_READ_CHUNK 4096
 
 void
 addReplyHTTPHeader (
@@ -42,10 +45,69 @@ addReplyHTTPHeader (
   sdsfree(http_header);
 }
 
-void
-processHTTPRequest (
-  client               *c
-) {
+void readHTTPRequest (aeEventLoop *el, int fd, void *privdata, int mask) {
+  UNUSED(el);
+  UNUSED(mask);
+  struct HttpClient *pclient = (struct HttpClient*)privdata;
+  /* BUGBUG This is just a proof of concept for the reading code, I'm sure there's a better way */
+  if ((pclient->cbQueryAlloc - pclient->cbQuery) < HTTP_READ_CHUNK)
+  {
+    pclient->cbQueryAlloc += HTTP_READ_CHUNK; // REVIEW: Growth limits?
+    pclient->szQuery = zrealloc(pclient->szQuery, pclient->cbQueryAlloc, MALLOC_LOCAL); // REVIEW handle NULL
+  }
+  ssize_t cbRead = read(fd, pclient->szQuery + pclient->cbQuery, HTTP_READ_CHUNK-1);
+  if (cbRead < 0)
+  {
+    if (errno != EAGAIN)
+      perror("Failed to read from HTTP socket");
+    serverAssert(errno == EAGAIN);  // REVIEW: Handle other errors
+    return;
+  }
+  else if (cbRead > 0)
+  {
+    pclient->cbQuery += cbRead;
+    pclient->szQuery[pclient->cbQuery] = '\0';
+    processHTTPRequest(el, pclient);
+  }
+}
+
+#define MAX_ACCEPTS_PER_CALL 1000
+void acceptHttpTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
+  int cport, cfd, max = MAX_ACCEPTS_PER_CALL;
+  char cip[NET_IP_STR_LEN];
+  UNUSED(mask);
+  UNUSED(privdata);
+
+  while(max--) 
+  {
+    cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
+    if (cfd == ANET_ERR) {
+        if (errno != EWOULDBLOCK)
+            serverLog(LL_WARNING,
+                "Accepting HTTP connection: %s", server.neterr);
+        return;
+    }
+    serverLog(LL_VERBOSE,"HTTP Accepted %s:%d", cip, cport);
+
+    struct HttpClient *pclient = (struct HttpClient*)zmalloc(sizeof(struct HttpClient), MALLOC_LOCAL);
+    if (pclient != NULL) {
+      pclient->fd = cfd;
+      pclient->cbQuery = 0;
+      pclient->cbQueryAlloc = 0;
+      pclient->szQuery = NULL;
+    }
+
+    if (pclient == NULL || aeCreateFileEvent(el,pclient->fd,AE_READABLE, readHTTPRequest, pclient) == AE_ERR)
+    {
+      close(cfd);
+      serverLog(LL_WARNING, "Failed to create HTTP listener event");
+      return;
+    }
+  }
+}
+
+void processHTTPRequest(aeEventLoop *el, struct HttpClient *pclient)
+{
   const char *method;
   size_t method_len;
   const char *path;
@@ -54,13 +116,14 @@ processHTTPRequest (
   struct phr_header headers[64];
   size_t num_headers;
   int pret;
+  int fd = pclient->fd;
 
   num_headers = sizeof(headers) / sizeof(headers[0]);
-  pret = phr_parse_request(c->querybuf, sdslen(c->querybuf), &method, &method_len,
+  pret = phr_parse_request(pclient->szQuery, pclient->cbQuery, &method, &method_len,
     &path, &path_len, &minor_version, headers, &num_headers, 0);
   switch (pret) {
     case -2:
-      printf("Incomplete HTTP request... need more data");
+      printf("Incomplete HTTP request... need more data\n");
       return;
       break;
     case -1:
@@ -92,7 +155,7 @@ processHTTPRequest (
   }
 
   robj *keyname = 0 == path_len ? createStringObject("/",1) : createStringObject(path, path_len);
-  robj *o = lookupKeyRead(c->db,keyname);
+  robj *o = lookupKeyRead(server.db,keyname); // REVIEW: We probably want to have more control over DB selection
 
   /* If there is no such key, return with a HTTP error. */
   if (o == NULL || o->type != OBJ_STRING) {
@@ -102,15 +165,32 @@ processHTTPRequest (
       else
           errstr = "Error: selected key type is invalid "
                    "for HTTP output";
-      addReplyProto(c, "HTTP/1.0 404 Not Found\r\n\r\n", 26);
+      write(fd, "HTTP/1.0 404 Not Found\r\n\r\n", 26);
   } else {
-      addReplyProto(c, "HTTP/1.0 200 OK\r\n", 17);
-      addReplyHTTPHeader(c, "Content-type", "text/plain");
-      addReplyProto(c, "\r\n", 2);
-      addReply(c,o);
+    write(fd, "HTTP/1.0 200 OK\r\n", 17);
+    write(fd, "Content-type: text/plain\r\n\r\n", 28);
+    
+    /* Note: This is stolen from addReply - it needs to be factored out into a common function */
+    if (sdsEncodedObject(o)) {
+        write(fd, (const char*)ptrFromObj(o), sdslen((sds)ptrFromObj(o)));
+    } else if (o->encoding == OBJ_ENCODING_INT) {
+        /* For integer encoded strings we just convert it into a string
+         * using our optimized function, and attach the resulting string
+         * to the output buffer. */
+        char buf[32];
+        size_t len = ll2string(buf,sizeof(buf),(long)ptrFromObj(o));
+        write(fd, buf, len);
+    } else {
+        serverPanic("Wrong obj->encoding in addReply()");
+    }
+    write(fd, "\r\n", 2);
   }
 
   if (0 == path_len) {
     decrRefCount(keyname);
   }
+
+  aeDeleteFileEvent(el, fd, AE_READABLE);
+  close(fd);
+  zfree(pclient);
 }

--- a/src/http.h
+++ b/src/http.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct HttpClient
+{
+  int fd;
+  size_t cbQuery;
+  size_t cbQueryAlloc;
+  char *szQuery;
+};
+
+void processHTTPRequest(aeEventLoop *el, struct HttpClient *pclient);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/networking.cpp
+++ b/src/networking.cpp
@@ -1979,33 +1979,6 @@ void processInputBuffer(client *c) {
         if (c->reqtype == PROTO_REQ_INLINE) {
             if (processInlineBuffer(c) != C_OK) break;
 
-            /*
-             * FIXME - This is an ugly ass hack.
-             *
-             * This should be entirely refactored such that it's handled prior
-             * to processInlineBuffer and, probably, knowingly that it's an
-             * HTTP handler either by using a separate event loop or marking
-             * the client as an HTTP client on accept (maybe based on port)?
-             */
-            if (server.http_enabled
-                && (3 == c->argc
-                    && ('G' == ((char*)(ptrFromObj(c->argv[0])))[0]
-                        && 'E' == ((char*)(ptrFromObj(c->argv[0])))[1]
-                        && 'T' == ((char*)(ptrFromObj(c->argv[0])))[2]))) {
-              AeLocker locker;
-              locker.arm(c);
-              server.current_client = c;
-              processHTTPRequest(c);
-              resetClient(c);
-              c->flags |= CLIENT_CLOSE_AFTER_REPLY;
-              if (server.current_client == NULL) {
-                  fFreed = true;
-                  break;
-              }
-              server.current_client = NULL;
-              break;
-            }
-
             /* If the Gopher mode and we got zero or one argument, process
              * the request in Gopher mode. */
             if (server.gopher_enabled &&

--- a/src/server.h
+++ b/src/server.h
@@ -77,6 +77,7 @@ typedef long long mstime_t; /* millisecond time type. */
                            N-elements flat arrays */
 #include "rax.h"     /* Radix tree */
 #include "uuid.h"
+#include "http.h"
 
 /* Following includes allow test functions to be called from Redis main() */
 #include "zipmap.h"
@@ -1064,7 +1065,9 @@ struct clusterState;
 struct redisServerThreadVars {
     aeEventLoop *el;
     int ipfd[CONFIG_BINDADDR_MAX]; /* TCP socket file descriptors */
-    int ipfd_count;             /* Used slots in ipfd[] */
+    int ipfd_count;                 /* Used slots in ipfd[] */
+    int ipfd_http[CONFIG_BINDADDR_MAX];
+    int ipfd_http_count;
     list *clients_pending_write; /* There is to write or install handler. */
     list *unblocked_clients;     /* list of clients to unblock before next loop NOT THREADSAFE */
     list *clients_pending_asyncwrite;
@@ -1602,7 +1605,6 @@ void setDeferredPushLen(client *c, void *node, long length);
 void processInputBuffer(client *c);
 void processInputBufferAndReplicate(client *c);
 void processGopherRequest(client *c);
-void processHTTPRequest(client *c);
 void acceptHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask);


### PR DESCRIPTION
The main reason to do it this way is to keep the HTTP requests completely out of band of the Redis REPL requests.  REPL is a security nightmare and to be useful this feature needs to be publicly visible.

It does mean we have to redo some of the read/write logic that we otherwise got for free but I think the trade off is necessary.

Note: This might even be more hacky than your original code, as I don't handle errors properly.  But this way we can collaborate without having to flesh everything out upfront.